### PR TITLE
Manage default marathon-lb certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Included b-log version 0.4.0
 * Updated Marathon-LB main version v1.11.3
 * Bug fixing with race conditions
+* Bug fixing with dead connections to Vault
+* Ensure the default marathon-lb certificate to be present by SNI if there's no certificate for the concrete app
+* Add iptables rules in position 2 if a calico rule is present
 
 ## 0.2.0 (December 19, 2017)
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -57,7 +57,7 @@ from utils import (CurlHttpEventStream, get_task_ip_and_ports, ip_cache,
 
 logger = None
 SERVICE_PORT_ASSIGNER = ServicePortAssigner()
-
+mlb_cert_name = ""
 
 class MarathonBackend(object):
 
@@ -1554,7 +1554,7 @@ def download_certificates_from_vault(app_map_array, ssl_certs):
 
     logger.debug("Clean certificates not present in the current appid list")
     for certfile in os.listdir(ssl_certs):
-        if not any(certfile in elem for elem in currentListAppidCert) and certfile != 'marathon-lb.pem':
+        if not any(certfile in elem for elem in currentListAppidCert) and certfile != mlb_cert_name:
             os.remove(os.path.join(ssl_certs, certfile))
             logger.info("Deleted certificate " + certfile)
 
@@ -1779,6 +1779,9 @@ def get_arg_parser():
     parser = argparse.ArgumentParser(
         description="Marathon HAProxy Load Balancer",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--marathon-lb-cert-name",
+                        help="Default marathon-lb certificate name",
+                        default="marathon-lb.pem"
     parser.add_argument("--longhelp",
                         help="Print out configuration details",
                         action="store_true"
@@ -1913,6 +1916,8 @@ if __name__ == '__main__':
     kms_utils.init_log()
     # Setup logging
     #setup_logging(logger, args.syslog_socket, args.log_format, args.log_level)
+
+    mlb_cert_name = args.marathon_lb_cert_name
 
     # initialize health check LRU cache
     if args.health_check:

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -1782,6 +1782,7 @@ def get_arg_parser():
     parser.add_argument("--marathon-lb-cert-name",
                         help="Default marathon-lb certificate name",
                         default="marathon-lb.pem"
+                        )
     parser.add_argument("--longhelp",
                         help="Print out configuration details",
                         action="store_true"

--- a/run
+++ b/run
@@ -193,7 +193,7 @@ cat > $LB_SERVICE/run << EOF
 exec 2>&1
 cd /marathon-lb
 exec /marathon-lb/marathon_lb.py \
-    --marathon-lb-cert-name "$MARATHON_LB_CERT_NAME"
+    --marathon-lb-cert-name "$MARATHON_LB_CERT_NAME" \
     --syslog-socket $SYSLOG_SOCKET \
     --haproxy-config /marathon-lb/haproxy.cfg \
     --ssl-certs "${SSL_CERTS}" \

--- a/run
+++ b/run
@@ -21,6 +21,8 @@ eval LOG_LEVEL_${DOCKER_LOG_LEVEL}
 # # # # # # # # #
 VAULT_ENABLED=0
 
+MARATHON_LB_CERT_NAME="000_marathon-lb.pem"
+
 # KMS_UTILS & Dynamic authentication
 if [ -n "${STRING_VAULT_HOST-}" ] && [ -n "${VAULT_PORT-}" ]; then
   OLD_IFS=${IFS}
@@ -112,6 +114,10 @@ if [ ${VAULT_ENABLED} -eq 1 ]; then
   chmod 644 "$SSL_CERTS/marathon-lb.pem"
   cat "$SSL_CERTS/marathon-lb.key" >> "$SSL_CERTS/marathon-lb.pem"
   rm -f "$SSL_CERTS/marathon-lb.key"
+  # Change the name to be the first alphabetical order certificate (SNI)
+  mv "$SSL_CERTS/marathon-lb.pem" "$SSL_CERTS/$MARATHON_LB_CERT_NAME"
+  # Copy the certificate to make it available in the old default path
+  cp "$SSL_CERTS/$MARATHON_LB_CERT_NAME" /etc/ssl/cert.pem
 	
   SSL_CERTS="$SSL_CERTS/"
   INFO "Downloaded"
@@ -187,6 +193,7 @@ cat > $LB_SERVICE/run << EOF
 exec 2>&1
 cd /marathon-lb
 exec /marathon-lb/marathon_lb.py \
+    --marathon-lb-cert-name "$MARATHON_LB_CERT_NAME"
     --syslog-socket $SYSLOG_SOCKET \
     --haproxy-config /marathon-lb/haproxy.cfg \
     --ssl-certs "${SSL_CERTS}" \


### PR DESCRIPTION
Manage default marathon-lb certificate to present by default in a non match by SNI, and make it available on the old path /etc/ssl/cert.pem